### PR TITLE
changed `output_notebook` and `show` imports to use bokeh.io instead …

### DIFF
--- a/tutorial/01 - plotting.ipynb
+++ b/tutorial/01 - plotting.ipynb
@@ -50,13 +50,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "from bokeh.plotting import figure, output_notebook, show"
+    "from bokeh.io import output_notebook, show\n",
+    "from bokeh.plotting import figure"
    ]
   },
   {

--- a/tutorial/02 - charts.ipynb
+++ b/tutorial/02 - charts.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -31,7 +31,7 @@
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
-    "from bokeh.charts import output_notebook, show"
+    "from bokeh.io import output_notebook, show"
    ]
   },
   {

--- a/tutorial/04 - styling.ipynb
+++ b/tutorial/04 - styling.ipynb
@@ -29,7 +29,8 @@
    },
    "outputs": [],
    "source": [
-    "from bokeh.plotting import figure, output_notebook, show"
+    "from bokeh.io import output_notebook, show\n",
+    "from bokeh.plotting import figure"
    ]
   },
   {


### PR DESCRIPTION
…of bokeh.plotting / bokeh.charts

While going through tutorials, I found it a bit confusing to import the same function (`output_notebook` and `show`) from different python modules.  Here I have standardized the existing notebooks to import these from `bokeh.io`.