### PR TITLE
Changed Callback to CustomJS

### DIFF
--- a/tutorial/06 - interactions.ipynb
+++ b/tutorial/06 - interactions.ipynb
@@ -734,7 +734,7 @@
     }
    ],
    "source": [
-    "from IPython.html.widgets import interact\n",
+    "from ipywidgets import interact\n",
     "interact(update, f=[\"sin\", \"cos\", \"tan\"], w=(0,10, 0.1), A=(0,5, 0.1), phi=(0, 10, 0.1))"
    ]
   },
@@ -751,7 +751,7 @@
    "source": [
     "## Adding Widgets\n",
     "\n",
-    "Bokeh supports direct integration with a small basic widget set. Thse can be used in conjunction with a Bokeh Server, or with ``Callback`` models to add more interactive capability to your documents. You can see a complete list, with example code in the [Adding Widgets](http://bokeh.pydata.org/en/latest/docs/user_guide/interaction.html#adding-widgets) section of the User's Guide. \n",
+    "Bokeh supports direct integration with a small basic widget set. Thse can be used in conjunction with a Bokeh Server, or with ``CustomJS`` models to add more interactive capability to your documents. You can see a complete list, with example code in the [Adding Widgets](http://bokeh.pydata.org/en/latest/docs/user_guide/interaction.html#adding-widgets) section of the User's Guide. \n",
     "\n",
     "To use the widgets, include them in a layout like you would a plot object:"
    ]
@@ -796,6 +796,7 @@
    ],
    "source": [
     "from bokeh.models.widgets import Slider\n",
+    "from bokeh.io import vform\n",
     "\n",
     "slider = Slider(start=0, end=10, value=1, step=.1, title=\"foo\")\n",
     "\n",
@@ -819,7 +820,7 @@
    "source": [
     "## Callbacks for widgets\n",
     "\n",
-    "Widgets that have values associated can have small JavaScript actions attached to them. These actions (also referred to as \"callbacks\") are executed whenever the widget's value is changed. In order to make it easier to refer to specific Bokeh models (e.g., a data source, or a glyhph) from JavaScript, the ``Callback`` obejct also accepts a dictionary of \"args\" that map names to Python Bokeh models. The corresponding JavaScript models are made available automaticaly to the ``Callback`` code. \n",
+    "Widgets that have values associated can have small JavaScript actions attached to them. These actions (also referred to as \"callbacks\") are executed whenever the widget's value is changed. In order to make it easier to refer to specific Bokeh models (e.g., a data source, or a glyhph) from JavaScript, the ``CustomJS`` obejct also accepts a dictionary of \"args\" that map names to Python Bokeh models. The corresponding JavaScript models are made available automaticaly to the ``CustomJS`` code. \n",
     "\n",
     "And example below shows an action attached to a slider that updates a data source whenever the slider is moved:"
    ]
@@ -864,7 +865,7 @@
    ],
    "source": [
     "from bokeh.io import vform\n",
-    "from bokeh.models import Callback, ColumnDataSource, Slider\n",
+    "from bokeh.models import CustomJS, ColumnDataSource, Slider\n",
     "\n",
     "x = [x*0.005 for x in range(0, 200)]\n",
     "y = x\n",
@@ -874,7 +875,7 @@
     "plot = figure(plot_width=400, plot_height=400)\n",
     "plot.line('x', 'y', source=source, line_width=3, line_alpha=0.6)\n",
     "\n",
-    "callback = Callback(args=dict(source=source), code=\"\"\"\n",
+    "callback = CustomJS(args=dict(source=source), code=\"\"\"\n",
     "    var data = source.get('data');\n",
     "    var f = cb_obj.get('value')\n",
     "    x = data['x']\n",
@@ -898,7 +899,7 @@
    "source": [
     "## Calbacks for selections\n",
     "\n",
-    "It's also possible to make JavaScript actions that execute whenever a user selection (e.g., box, point, lasso) changes. This is done by attaching the same kind of Callback object to whatever data source the selection is made on.\n",
+    "It's also possible to make JavaScript actions that execute whenever a user selection (e.g., box, point, lasso) changes. This is done by attaching the same kind of CustomJS object to whatever data source the selection is made on.\n",
     "\n",
     "The example below is a bit more sophisticaed, and demonstrates updating one glyphs data source in response to another glyph's selection: "
    ]
@@ -955,7 +956,7 @@
     "s2 = ColumnDataSource(data=dict(ym=[0.5, 0.5]))\n",
     "p.line(x=[0,1], y='ym', color=\"orange\", line_width=5, alpha=0.6, source=s2)\n",
     "\n",
-    "s.callback = Callback(args=dict(s2=s2), code=\"\"\"\n",
+    "s.callback = CustomJS(args=dict(s2=s2), code=\"\"\"\n",
     "    var inds = cb_obj.get('selected')['1d'].indices;\n",
     "    var d = cb_obj.get('data');\n",
     "    var ym = 0\n",

--- a/tutorial/bubble_plot.py
+++ b/tutorial/bubble_plot.py
@@ -8,7 +8,8 @@ from bokeh.embed import components
 from bokeh.models import (
     ColumnDataSource, Plot, Circle, Range1d,
     LinearAxis, HoverTool, Text,
-    SingleIntervalTicker, Slider, Callback
+    SingleIntervalTicker, Slider, CustomJS,
+    WheelZoomTool, PanTool, ResetTool
 )
 from bokeh.palettes import Spectral6
 from bokeh.plotting import vplot, hplot
@@ -137,7 +138,7 @@ def _get_plot():
         text_source.trigger('change');
     """ % js_source_array
 
-    callback = Callback(args=sources, code=code)
+    callback = CustomJS(args=sources, code=code)
     slider = Slider(start=years[0], end=years[-1], value=1, step=1, title="Year", callback=callback)
     callback.args["slider"] = slider
     callback.args["renderer_source"] = renderer_source


### PR DESCRIPTION
Callback appears to be depricated. All calls to bokeh.models.Callback
have been updated to bokeh.models.CustomJS.

These notebooks were tested in Anaconda 2.3.0 with the following
package versions:
  bokeh      0.9.3
  ipython    4.0.0
  ipywidgets 4.0.3
  numpy      1.9.2
  pandas     0.16.2
  python     3.4.3

Note that IPython.html.widgets is now ipywidgets