### PR TITLE
Fixing some typos and updating Datashader function calls

### DIFF
--- a/tutorial/00 - intro.ipynb
+++ b/tutorial/00 - intro.ipynb
@@ -427,7 +427,7 @@
    "source": [
     "# Plot a complex chart in a single line\n",
     "\n",
-    "from bokeh.charts import Histogram\n",
+    "from bkcharts import Histogram\n",
     "from bokeh.sampledata.iris import flowers as data\n",
     "\n",
     "hist = Histogram(data, values=\"petal_length\", color=\"species\", legend=\"top_right\", bins=12)\n",

--- a/tutorial/03 - interactions.ipynb
+++ b/tutorial/03 - interactions.ipynb
@@ -830,7 +830,7 @@
    "source": [
     "# Hover Tools\n",
     "\n",
-    "Bokeh has a Hover Tool that allows additional information to be displayed in a popup whenever the uer howevers over a specific glyph. Basic hover tool configuration amounts to providing a list of ``(name, format)`` tuples. The full details can be found in the User's Guide [here](http://bokeh.pydata.org/en/latest/docs/user_guide/tools.html#hovertool).\n",
+    "Bokeh has a Hover Tool that allows additional information to be displayed in a popup whenever the user hovers over a specific glyph. Basic hover tool configuration amounts to providing a list of ``(name, format)`` tuples. The full details can be found in the User's Guide [here](http://bokeh.pydata.org/en/latest/docs/user_guide/tools.html#hovertool).\n",
     "\n",
     "The example below shows some basic usage of the Hover tool with a circle glyph, using hover information defined in utils.py:"
    ]

--- a/tutorial/09 - models.ipynb
+++ b/tutorial/09 - models.ipynb
@@ -1414,7 +1414,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This JavaScript implememtation is then attached to a corresponding Python Bokeh model:"
+    "This JavaScript implementation is then attached to a corresponding Python Bokeh model:"
    ]
   },
   {

--- a/tutorial/12 - datashader.ipynb
+++ b/tutorial/12 - datashader.ipynb
@@ -243,7 +243,7 @@
     "import datashader as ds\n",
     "import datashader.transfer_functions as tf\n",
     "\n",
-    "%time tf.interpolate(ds.Canvas().points(df,'x','y'))"
+    "%time tf.shade(ds.Canvas().points(df,'x','y'))"
    ]
   },
   {
@@ -326,7 +326,7 @@
    "outputs": [],
    "source": [
     "### EXERCISE: try some of these other reduction operators and see if you can understand the \n",
-    "### resulting differences in the plots.  The arr can be visualized using `tf.interpolate(arr)` \n",
+    "### resulting differences in the plots.  The arr can be visualized using `tf.shade(arr)` \n",
     "### for most reduction operators (other than count_cat, below)."
    ]
   },
@@ -377,7 +377,7 @@
     }
    ],
    "source": [
-    "tf.interpolate(agg.where(agg>=np.percentile(agg,99)))"
+    "tf.shade(agg.where(agg>=np.percentile(agg,99)))"
    ]
   },
   {
@@ -431,7 +431,7 @@
     }
    ],
    "source": [
-    "tf.interpolate(np.sin(agg))"
+    "tf.shade(np.sin(agg))"
    ]
   },
   {
@@ -505,7 +505,7 @@
     }
    ],
    "source": [
-    "tf.interpolate(agg, cmap=[\"darkred\", \"yellow\"])"
+    "tf.shade(agg, cmap=[\"darkred\", \"yellow\"])"
    ]
   },
   {
@@ -559,7 +559,7 @@
     }
    ],
    "source": [
-    "tf.interpolate(agg,cmap=[\"darkred\", \"yellow\"],how='linear')"
+    "tf.shade(agg,cmap=[\"darkred\", \"yellow\"],how='linear')"
    ]
   },
   {
@@ -606,7 +606,7 @@
     }
    ],
    "source": [
-    "tf.interpolate(agg,cmap=[\"darkred\", \"yellow\"],how='log')"
+    "tf.shade(agg,cmap=[\"darkred\", \"yellow\"],how='log')"
    ]
   },
   {
@@ -653,7 +653,7 @@
     }
    ],
    "source": [
-    "tf.interpolate(agg,cmap=[\"darkred\", \"yellow\"],how='eq_hist')"
+    "tf.shade(agg,cmap=[\"darkred\", \"yellow\"],how='eq_hist')"
    ]
   },
   {
@@ -712,7 +712,7 @@
    "source": [
     "color_key = dict(d1='blue', d2='green', d3='red', d4='orange', d5='purple')\n",
     "aggc = canvas.points(df, 'x', 'y', ds.count_cat('cat'))\n",
-    "tf.colorize(aggc, color_key)"
+    "tf.shade(aggc, color_key)"
    ]
   },
   {
@@ -773,7 +773,7 @@
     }
    ],
    "source": [
-    "tf.spread(tf.colorize(aggc, color_key))"
+    "tf.spread(tf.shade(aggc, color_key))"
    ]
   },
   {
@@ -1122,7 +1122,7 @@
     "def image_callback(x_range, y_range, w, h):\n",
     "    cvs = ds.Canvas(plot_width=w, plot_height=h, x_range=x_range, y_range=y_range)\n",
     "    agg = cvs.points(df, 'x', 'y', ds.count_cat('cat'))\n",
-    "    img = tf.colorize(agg, color_key)\n",
+    "    img = tf.shade(agg, color_key)\n",
     "    return tf.dynspread(img, threshold=0.25)\n",
     "\n",
     "InteractiveImage(p, image_callback)"

--- a/tutorial/A1 - Extra Resources.ipynb
+++ b/tutorial/A1 - Extra Resources.ipynb
@@ -47,7 +47,7 @@
     "\n",
     "##### User's Guide - http://bokeh.pydata.org/en/latest/docs/user_guide.html\n",
     "\n",
-    "The user's guide has many top-oriented subsections, for example \"Plotting with Basic Glyphs\", \"Configuring Plot Tools\", or \"Adding Interactions\". Each user's guide section typically example code and corresponding live plots that demomnstrate how to accomplish various tasks. \n",
+    "The user's guide has many top-oriented subsections, for example \"Plotting with Basic Glyphs\", \"Configuring Plot Tools\", or \"Adding Interactions\". Each user's guide section typically example code and corresponding live plots that demonstrate how to accomplish various tasks. \n",
     "\n",
     "---\n",
     "\n",
@@ -84,7 +84,6 @@
     "The `examples` directory has many subfolders dedicated to different kinds of topics. Some of the hightlights are:\n",
     "\n",
     "* `app` - example Bokeh apps, run with \"`bokeh serve`\"\n",
-    "* `charts` - examples using the `bokeh.charts` interface\n",
     "* `howto` - some examples arranged around specific topics such as layout or notebook comms\n",
     "* `plotting` - a large collections of examples using the `bokeh.plotting` interface\n",
     "* `webgl` - some examples demonstrating WebGL usage\n",
@@ -138,7 +137,7 @@
     "\n",
     "#### Developer's Guide - http://bokeh.pydata.org/en/latest/docs/dev_guide.html\n",
     "\n",
-    "If you are interesting in becoming a conributor to Bokeh, the developer's guide is the place to start. It has information about getting a development environment set up, the library arhcitecture, writing and running tests, "
+    "If you are interesting in becoming a contributor to Bokeh, the developer's guide is the place to start. It has information about getting a development environment set up, the library architecture, writing and running tests, "
    ]
   },
   {


### PR DESCRIPTION
Mostly various typo fixes, but in Tutorial 12, there were lots of instances where Datashader functions calls gave deprecation warnings because two functions (interpolate and colorize) have been merged into one.  

I do not know why the outputs in these notebooks are saved in the git repository, but I didn't mess with those in the interest of making my edits clear. However, the updated code now outputs only plots instead of error messages.  If having the output in the repo is important, maybe re-run and save your version.