### PR TITLE
fix typo in Applications

### DIFF
--- a/tutorial/00 - Introduction and Setup.ipynb
+++ b/tutorial/00 - Introduction and Setup.ipynb
@@ -40,7 +40,7 @@
     "8.  [Graph and Network Plots](08%20-%20Graph%20and%20Network%20Plots.ipynb)\n",
     "9.  [Geographic Plots](09%20-%20Geographic%20Plots.ipynb)\n",
     "10. [Exporting and Embedding](10%20-%20Exporting%20and%20Embedding.ipynb)\n",
-    "11. [Running Bokeh Applictions](11%20-%20Running%20Bokeh%20Applictions.ipynb)\n",
+    "11. [Running Bokeh Applications](11%20-%20Running%20Bokeh%20Applications.ipynb)\n",
     "\n",
     "As well as some extra topic appendices:\n",
     "\n",
@@ -699,7 +699,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/tutorial/11 - Running Bokeh Applications.ipynb
+++ b/tutorial/11 - Running Bokeh Applications.ipynb
@@ -729,7 +729,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Fix a typo that had Applic[a]tions misspelled in the Introductory notebook link and notebook. 
- Check that hyperlinks work. 