### PR TITLE
Fix markdown strong emphasis syntax.

### DIFF
--- a/quickstart/quickstart.ipynb
+++ b/quickstart/quickstart.ipynb
@@ -579,7 +579,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**This kind of approach can be used to generate other kinds of interesting plots. See many more examples in the [Bokeh Documentation Gallery](https://bokeh.pydata.org/en/latest/docs/gallery.html). **"
+    "**This kind of approach can be used to generate other kinds of interesting plots. See many more examples in the [Bokeh Documentation Gallery](https://bokeh.pydata.org/en/latest/docs/gallery.html).**"
    ]
   },
   {


### PR DESCRIPTION
This PR fixed a markdown strong emphasis syntax:

`**This kind ... Bokeh Documentation Gallery **`, there is a space before the closing `**`, which cause some markdown parser fail to recognize it.